### PR TITLE
Update MQTTSession.swift

### DIFF
--- a/SwiftMQTT/SwiftMQTT/MQTTSession.swift
+++ b/SwiftMQTT/SwiftMQTT/MQTTSession.swift
@@ -112,7 +112,7 @@ public class MQTTSession: MQTTSessionStreamDelegate {
     
     private func disconnectionCleanup() {
         stream.closeStreams()
-        keepAliveTimer.invalidate()
+        keepAliveTimer?.invalidate()
         self.delegate?.didDisconnectSession(self)
     }
     


### PR DESCRIPTION
Added an optional check for `keepAliveTimer` to prevent crash if `disconnectionCleanup()` was called before `keepAliveTimer` was instantiated.